### PR TITLE
Update LAB[PL-400]_Lab09_Custom_connectors.md

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab09_Custom_connectors.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab09_Custom_connectors.md
@@ -195,7 +195,7 @@ As part of configuring the custom connector, you will complete the following
 
     ![Create new component - screenshot](../L09/Static/Mod_2_Custom_Connector_image16.png)
 
-	- Select **Automation| Custom Connector**.
+	- Select **Automation** > **Custom Connector**.
 
     ![Create new custom connector - screenshot](../L09/Static/Mod_2_Custom_Connector_image17.png)
 


### PR DESCRIPTION
It's taking up a big space in exercise #2, task #1, line 2

# Module: 09
## Lab/Demo: Custom Connector

Fixes #  One of the steps in exercise #2, task #1, item 2 is to assume large spaces between words and some trainees are unaware of the next instruction. I also made a pull request of the new image.

