### PR TITLE
CanceledInspectionsCount is optional parameter

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab04_Client_Scripting.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab04_Client_Scripting.md
@@ -683,7 +683,7 @@ In this task, you will create a custom API that will be called to lock the permi
 
 	- Select **+ New** and then select **More | Other | Custom API Response Parameter**.
 
-	- Select **Lock Permit** for Custom API, enter **CanceledInspectionsCount** for Unique name, enter **Canceled Inspections Count** for Name, enter **Canceled Inspections Count** Display name, **Canceled Inspections Count** for Description, select **Integer** for Type, and select **Save and Close**.
+	- Select **Lock Permit** for Custom API, enter **CanceledInspectionsCount** for Unique name, enter **Canceled Inspections Count** for Name, enter **Canceled Inspections Count** Display name, **Canceled Inspections Count** for Description, select **Integer** for Type. set **Yes** for Is Optional, and select **Save and Close**.
 
     ![Process arguments - screenshot](../L04/Static/mod-01-client-scripting-80.png)
 


### PR DESCRIPTION
CanceledInspectionsCount should be an optional parameter, because in the following client script we not providing the value to this parameter.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-