### PR TITLE
Fix broken link for CDS/Dynamics 365 SDK download

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab06_Plugins.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab06_Plugins.md
@@ -191,7 +191,7 @@ As part of building the plugins, you will complete the following activities.
 
 1. If you don’t have CDS/Dynamics 365 SDK tools downloaded already, download them using the following method: 
 
-	- Navigate to [https://www.cds.tools/SDK](https://www.cds.tools/SDK) 
+	- Navigate to [https://xrm.tools/SDK](https://xrm.tools/SDK) 
 
 	- Select **Download SDK Zip File**.
 


### PR DESCRIPTION
Fix broken link for CDS/Dynamics 365 SDK download on labs 6; task #2; point 1

# Module: 6
## Lab/Demo: 6 – Plugins
### Task #2: Deploy the plugin



Changes proposed in this pull request:

-Fix broken link to get the Dynamics 365 SDK Tools