### PR TITLE
Fix typo in Permit record form instructions

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab08_Client_Scripting.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab08_Client_Scripting.md
@@ -281,7 +281,7 @@ In this task, you will test the event handlers.
 
 1. Confirm the OnLoad event handler function runs.
 
-   - In the **Permit** record form, select the **Refresh** cion.
+   - In the **Permit** record form, select the **Refresh** icon.
 
    - In the **Dev Tools** pane you should see the **on load – permit form** message.
 


### PR DESCRIPTION
# Module: 08
Lab 08 - Client Scripting

Fixes # Typo in instructions

Changes proposed in this pull request:

- Corrected spelling of "cion" to "icon" in the Permit record form instructions.
- Improved clarity of the instructions.

## Reference Screenshot of the typo mistake:
![image](https://github.com/user-attachments/assets/3f079652-1699-40a6-925f-4112310e6347)
