### PR TITLE
Correct reference to Function URL 

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab09_Azure.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab09_Azure.md
@@ -807,7 +807,7 @@ As part of configuring the custom connector, you will complete the following
 
      ![Rename custom connector - screenshot](../images/L09/Mod_2_Custom_Connector_image18.png)
 
-   - Locate the **Host** column and paste the **Function URL** you copied in Exercise 1.
+   - Locate the **Host** column and paste the **Function URL** you copied in Exercise 7.
 
    - Remove https:// and everything after .net.
 


### PR DESCRIPTION
# Module: 7
## Lab: 9

Fixes #161 

Changes proposed in this pull request:

- Reference to the Function URL from Task 7.1 in Task 8.2