### PR TITLE
Use reflection object for LockPermitCancelInspections in its constructor

### DIFF
--- a/Instructions/Labs/LAB[PL-400]_Lab08_Plugins.md
+++ b/Instructions/Labs/LAB[PL-400]_Lab08_Plugins.md
@@ -329,7 +329,7 @@ Complete source code files for this lab can be found in the  C:\Labfiles\L08\Res
 
      ```csharp
      public LockPermitCancelInspections(string unsecureConfiguration, string secureConfiguration)
-     : base(typeof(PreOperationPermitCreate))
+     : base(typeof(LockPermitCancelInspections))
      {
 
      }


### PR DESCRIPTION
# Module: 08
## Lab: 08

Task 2.1
Step 4

Fixes #192 .

Changes proposed in this pull request:

The constructor for LockPermitCancelInspections calls a base constructor and passes a reflection object for a different class, probably because it was copied and pasted from another class.

The solution file in Allfiles/Labs/L08/Resources/LockPermitCancelInspections.cs already has the correct code.
